### PR TITLE
Fixing NullPointer for CSV output when null value was returned from db

### DIFF
--- a/src/main/java/com/zenquery/api/ResultSetController.java
+++ b/src/main/java/com/zenquery/api/ResultSetController.java
@@ -415,7 +415,11 @@ public class ResultSetController {
             String[] columnOutputValues = new String[numberOfValues];
             for (int i = 0; i < numberOfValues; i++) {
                 Object columnValue = columnValues[i];
-                columnOutputValues[i] = columnValue.toString();
+                if (columnValue != null) {
+                  columnOutputValues[i] = columnValue.toString();
+                } else {
+                  columnOutputValues[i] = "";
+                }
             }
             outputRows.add(columnOutputValues);
         }


### PR DESCRIPTION
We had problem with NullPointerException while generating CSV, when query returned null value from database. With this fix such situation produces empty string in CSV file. 

Note - such problem does not occur with json or xml
